### PR TITLE
Allow fetching HEAD

### DIFF
--- a/anybox/recipe/odoo/vcs/git.py
+++ b/anybox/recipe/odoo/vcs/git.py
@@ -257,7 +257,7 @@ class GitRepo(BaseRepo):
                           log_level=logging.DEBUG)
 
             rtype, sha = self.query_remote_ref(BUILDOUT_ORIGIN, revision)
-            if rtype is None and ishex(revision):
+            if rtype is None and (ishex(revision) or revision == 'FETCH_HEAD'):
                 return self.fetch_remote_sha(revision)
 
             fetch_cmd = ['git', 'fetch']


### PR DESCRIPTION
`query_remote_ref` will return `None` for the ref `HEAD` and `FETCH_HEAD` but current implementation doesn't cover that case.

This allows using the deprecated `fetch_remote_sha` with `FETCH_HEAD` as was possible previously

Fixes #3