### PR TITLE
Fix check for `--no-edit` option to git 1.7.10

### DIFF
--- a/anybox/recipe/odoo/vcs/git.py
+++ b/anybox/recipe/odoo/vcs/git.py
@@ -381,9 +381,9 @@ class GitRepo(BaseRepo):
                                    self.target_dir)
             os.chdir(self.target_dir)
             cmd = ['git', 'pull', self.url, revision]
-            if self.git_version >= (1, 7, 8):
-                # --edit and --no-edit appear with Git 1.7.8
-                # see Documentation/RelNotes/1.7.8.txt of Git
+            if self.git_version >= (1, 7, 10):
+                # --edit and --no-edit appear with Git 1.7.10
+                # see Documentation/RelNotes/1.7.10.txt of Git
                 # (https://git.kernel.org/cgit/git/git.git/tree)
                 cmd.insert(2, '--no-edit')
 


### PR DESCRIPTION
`--no-edit` is unavailable in git 1.7.8 as was stated, causing issues in merge with git versions 1.7.8.* and 1.7.9.*

This is unfortunate for Ubuntu 12.04 where the package version is 1.7.9.5

See: 
* https://git.kernel.org/cgit/git/git.git/tree/Documentation/RelNotes/1.7.10.txt
* https://git.kernel.org/cgit/git/git.git/tree/Documentation/RelNotes/1.7.8.txt