### PR TITLE
Get context for session from SUPERUSER_ID

### DIFF
--- a/anybox/recipe/odoo/runtime/session.py
+++ b/anybox/recipe/odoo/runtime/session.py
@@ -178,6 +178,7 @@ class Session(object):
         self.init_cursor()
         self.uid = SUPERUSER_ID
         self.init_environments()
+        self.context = self.registry('res.users').context_get(self.cr, self.uid)
 
     def init_environments(self):
         """Enter the environments context manager, but don't leave it


### PR DESCRIPTION
Allow user to use a proper context as session.context
Prevent scripts from doing manipulations with default lang (en_US) on non en_US systems