### PR TITLE
fix issue on gunicorn.preload_databases

### DIFF
--- a/anybox/recipe/openerp/server.py
+++ b/anybox/recipe/openerp/server.py
@@ -220,7 +220,7 @@ conf = openerp.tools.config
                 "def post_fork(server, worker):",
                 "    '''Preload databases specified in buildout conf.'''",
                 "    from openerp.modules.registry import RegistryManager",
-                "    preload_dbs = %r" % preload_dbs,
+                "    preload_dbs = %r" % (preload_dbs,),
                 "    for db_name in preload_dbs:",
                 "        server.log.info('Worker loading database %r',",
                 "                        db_name)",


### PR DESCRIPTION
@gracinet as mentioned in private,

This fix regression issue using gunicorn.preload_databases from a.r.openerp-1.9.

I had got this FATAL error when launching bin/gunicorn_openerp
`OperationalError: FATAL: la base de données « o » n'existe pas`

