### PR TITLE
Master imp extract

### DIFF
--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -15,8 +15,8 @@ import distutils.core
 import pkg_resources
 try:
     from collections import OrderedDict
-except ImportError:  # Python < 2.7
-    from ordereddict import OrderedDict  # noqa
+except ImportError:  # Python < 2.7 pragma: no cover
+    from ordereddict import OrderedDict  # noqa pragma: no cover
 from zc.buildout.easy_install import MissingDistribution
 from zc.buildout import UserError
 from zc.buildout.easy_install import VersionConflict
@@ -504,7 +504,7 @@ class BaseRecipe(object):
 
         To be refined by subclasses.
         """
-        pass
+        pass  # pragma: no cover
 
     @property
     def major_version(self):

--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -1606,4 +1606,4 @@ class BaseRecipe(object):
     @classmethod
     def to_src_path(cls, base_path):
         return os.path.join('${buildout:odoo-src-dir}',
-                             base_path)
+                            base_path)

--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -1327,6 +1327,7 @@ class BaseRecipe(object):
             if local_path is main_software:
                 rel_path = self._extract_main_software(source_type, target_dir,
                                                        extracted)
+                rel_path = self.to_src_path(rel_path)
                 out_conf.set(self.name, 'version', 'local ' + rel_path)
                 continue
 
@@ -1343,7 +1344,7 @@ class BaseRecipe(object):
                         "does not have it as its parent" % (group, local_path))
             else:
                 target_local_path = local_path
-
+            target_local_path = self.to_src_path(target_local_path)
             addons_line = ['local', target_local_path]
             addons_line.extend('%s=%s' % (opt, val)
                                for opt, val in options.items())
@@ -1435,6 +1436,7 @@ class BaseRecipe(object):
         """
         conf.add_section('buildout')
         conf.set('buildout', 'extends', self.buildout_cfg_name())
+        conf.set('buildout', 'odoo-src-dir', '${buildout:directory}')
         conf.add_section('versions')
         conf.set('buildout', 'versions', 'versions')
 
@@ -1447,11 +1449,14 @@ class BaseRecipe(object):
             self._extract_vcs_source(vcs_type, abs_path,
                                      target_dir, target_sub_dir, extracted)
             # looks silly, but better for uniformity:
-            develops.add(target_sub_dir)
+            if target_sub_dir in develops:
+                develops.remove(target_sub_dir)
+            develops.add(abs_path)
 
         bdir = os.path.join(self.buildout_dir, '')
         conf.set('buildout', 'develop',
-                 os.linesep.join(d[len(bdir):] if d.startswith(bdir) else d
+                 os.linesep.join(self.to_src_path(d[len(bdir):]) if
+                                 d.startswith(bdir) else d
                                  for d in develops))
 
         # remove gp.vcsdevelop from extensions
@@ -1597,3 +1602,8 @@ class BaseRecipe(object):
                 return a[len(prefix):]
 
         return 'buildout.cfg'
+
+    @classmethod
+    def to_src_path(cls, base_path):
+        return os.path.join('${buildout:odoo-src-dir}',
+                             base_path)

--- a/anybox/recipe/odoo/tests/test_extract.py
+++ b/anybox/recipe/odoo/tests/test_extract.py
@@ -43,7 +43,8 @@ class TestExtraction(RecipeTestCase):
         self.recipe._extract_sources(conf, target_dir, extracted)
         addons_opt = set(conf.get('openerp', 'addons').split(os.linesep))
         self.assertEquals(addons_opt,
-                          set(('local vcs-addons', 'local specific')))
+                          set(('local ${buildout:odoo-src-dir}/vcs-addons',
+                               'local ${buildout:odoo-src-dir}/specific')))
         self.assertEquals(extracted,
                           set([os.path.join(target_dir, 'vcs-addons')]))
 
@@ -94,7 +95,8 @@ class TestExtraction(RecipeTestCase):
 
         develop = conf.get('buildout', 'develop').split(os.linesep)
         self.assertEquals(set(d for d in develop if d),
-                          set(['aeroolib', 'simple_develop']))
+                          set(['${buildout:odoo-src-dir}/aeroolib',
+                               '${buildout:odoo-src-dir}/simple_develop']))
 
         # extraction has been done
         target = os.path.join(self.extract_target_dir, 'aeroolib')
@@ -119,7 +121,8 @@ class TestExtraction(RecipeTestCase):
 
         develop = conf.get('buildout', 'develop').split(os.linesep)
         self.assertEquals(set(d for d in develop if d),
-                          set(['src/aeroolib', 'simple_develop']))
+                          set(['${buildout:odoo-src-dir}/src/aeroolib',
+                               '${buildout:odoo-src-dir}/simple_develop']))
 
         # extraction has been done
         target = os.path.join(self.extract_target_dir, 'src', 'aeroolib')
@@ -168,11 +171,12 @@ class TestExtraction(RecipeTestCase):
 
         # notice standalone handling :
         self.assertEqual(ext_conf.get('openerp', 'addons').splitlines(),
-                         ['local target', 'local somwehere',
-                          'local stdl'])
+                         ['local ${buildout:odoo-src-dir}/target',
+                          'local ${buildout:odoo-src-dir}/somwehere',
+                          'local ${buildout:odoo-src-dir}/stdl'])
 
         self.assertEqual(ext_conf.get('openerp', 'version').strip(),
-                         'local parts/odooo')
+                         'local ${buildout:odoo-src-dir}/parts/odooo')
         # precise version depends on the setuptools version
         # from about setuptools 8.2 or 8.3, normalization to 0.123.dev0
         # according to PEP440 occurs


### PR DESCRIPTION
By default, all paths in a buildout, if not absolutes, are always
resolved as a child of ${buildout:diretory}. When extracting the sources
to a release directory it's therefore not possible to run the buildout
from outside the generated release directory. By prepending  paths of
the extracted sources with an overridable property, it's now possible
to execute buildout from outside of the release directory without
modification to the generated config file.
