### PR TITLE
V8 env

### DIFF
--- a/anybox/recipe/odoo/runtime/session.py
+++ b/anybox/recipe/odoo/runtime/session.py
@@ -178,6 +178,7 @@ class Session(object):
         self.init_cursor()
         self.uid = SUPERUSER_ID
         self.init_environments()
+        self.context = self.registry('res.users').context_get(self.cr, self.uid)
 
     def init_environments(self):
         """Enter the environments context manager, but don't leave it

--- a/anybox/recipe/odoo/runtime/session.py
+++ b/anybox/recipe/odoo/runtime/session.py
@@ -179,6 +179,8 @@ class Session(object):
         self.uid = SUPERUSER_ID
         self.init_environments()
         self.context = self.registry('res.users').context_get(self.cr, self.uid)
+        if hasattr(openerp, 'api'):
+            self.env = openerp.api.Environment(self.cr, self.uid, self.context)
 
     def init_environments(self):
         """Enter the environments context manager, but don't leave it


### PR DESCRIPTION
Create an api Environment with cursor, user id and context of superuser
This allows the following syntax from the get-go:

    new_partner = self.env['res.partner'].create({'name': 'bwrsandman'})

The syntax is consistent with api decorated functions and the Odoo unittest framework

Depends on #27

