### PR TITLE
Ensuring that pip is provided to integrations tests

### DIFF
--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -172,6 +172,8 @@ class BaseRecipe(object):
         self.clear_retry = clear_retry == 'true'
 
         if self.bool_opt_get(WITH_ODOO_REQUIREMENTS_FILE_OPTION):
+            logger.debug("%s option: adding 'pip' to the recipe requirements",
+                         WITH_ODOO_REQUIREMENTS_FILE_OPTION)
             self.with_odoo_requirements_file = True
             self.recipe_requirements = list(self.recipe_requirements)
             self.recipe_requirements.append('pip')

--- a/anybox/recipe/odoo/tests/test_integration_server.py
+++ b/anybox/recipe/odoo/tests/test_integration_server.py
@@ -26,16 +26,17 @@ class IntegrationTestCase(unittest.TestCase):
         self.versions_original = deepcopy(Installer._versions)
         self.cwd_original = os.getcwd()
         self.pip_original = pip_original
-
         try:
             sandbox = mkdtemp('test_int_oerp_base_recipe')
             self.buildout_dir = os.path.join(sandbox, 'buildout_dir')
             shutil.copytree(os.path.join(TEST_DIR, 'integration_buildouts'),
                             self.buildout_dir)
             os.chdir(self.buildout_dir)
+
             autopath = buildout_and_setuptools_path
             self.autopath_original = autopath[:]
-            autopath.append(working_set.find(Requirement.parse('pip')).location)
+            pip_loc = working_set.find(Requirement.parse('pip')).location
+            autopath.append(pip_loc)
         except:
             self.tearDown()
             raise

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ if sys.version_info < (2, 6):
                      "Yours is " + sys.version + os.linesep)
     sys.exit(1)
 
-requires = ['setuptools', 'zc.recipe.egg', 'zc.buildout>=2.2.0']
+# a sufficient version of pip is needed to parse Odoo requirement file
+# version 1.4.1 is the one required by reportlab anyway
+requires = ['setuptools', 'zc.recipe.egg', 'zc.buildout>=2.2.0', 'pip>=1.4.1']
 
 if sys.version_info < (2, 7):
     requires.append('ordereddict')


### PR DESCRIPTION
First merge of the branch for Github #43 showed that these tests actually
relied on a side effect of zc.buildout machinery.
Indeed, buildout automatically adds the location of the setuptools
distribution, and in case that's a whole (virtualenv) site-packages, it also
provides pip. But there are lots of situations where setuptools would be from
its own, separate location (egg installed by setup.py develop --upgrade)

We actually do the same for pip, with the drawback that we
actually make exposure of the whole site-packages more frequent in those
integration tests, but that's safer than the alternative, that'd have been
to lay an egg manually built from the available pip.

We are sure that pip is available, because it's now a requirement.
The new feature (apply-requirements-file) does not work for older pip versions
anyway (seen with 1.1)