### PR TITLE
opt-in BUILDOUT_SKIP_PG_USER_CHECK #63

### DIFF
--- a/anybox/recipe/odoo/runtime/session.py
+++ b/anybox/recipe/odoo/runtime/session.py
@@ -162,7 +162,8 @@ class Session(object):
         cr.close()
 
         startup.check_root_user()
-        startup.check_postgres_user()
+        if not os.environ.get('ENABLE_POSTGRES_USER'):
+            startup.check_postgres_user()
         openerp.netsvc.init_logger()
 
         saved_without_demo = config['without_demo']

--- a/doc/scripts.rst
+++ b/doc/scripts.rst
@@ -248,6 +248,14 @@ object is available for interacting with your odoo application and database.
 Keep in mind that ``bpython`` requires more system dependencies installed than
 plain ``odoo``.
 
+Note that Odoo forbids using the ``postgres`` user to connect to the database.
+But in some containerized environments (Docker), using ``postgres`` can be
+both safe and handy. In such case you would need to patch the Odoo server as
+of today. But for the interactives sessions of this buildout recipe, you can
+set the environment variable ENABLE_POSTGRES_USER=1 before opening the console
+to disable the default ``check_postgres_user()`` guard and enable the postgres
+user.
+
 Writing Odoo Scripts
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This new env var enables to skip the postgres user check. This can be handy when linking to some default Postgres containers.
See https://github.com/anybox/anybox.recipe.odoo/issues/63