### PR TITLE
Add the option to not insert the base_addons folder as the first one …

### DIFF
--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -1501,8 +1501,9 @@ class BaseRecipe(object):
 
         base_addons = join(self.openerp_dir, 'openerp', 'addons')
         if os.path.exists(base_addons):
-            # Sometimes we don't want the base addons to be charged as the first ones 
-            # (if we have addons with the same names: like enterprise vs standard addons
+            # Sometimes we don't want the base addons to be charged as 
+            # the first ones (if we have addons with the same names: like 
+            # enterprise vs standard addons)
             if self.options.get('keep-addons-order', False) == 'True':
                 self.addons_paths.append(base_addons)
             else:

--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -1501,8 +1501,8 @@ class BaseRecipe(object):
 
         base_addons = join(self.openerp_dir, 'openerp', 'addons')
         if os.path.exists(base_addons):
-            # Sometimes we don't want the base addons to be charged as 
-            # the first ones (if we have addons with the same names: like 
+            # Sometimes we don't want the base addons to be charged as
+            # the first ones (if we have addons with the same names: like
             # enterprise vs standard addons)
             if self.options.get('keep-addons-order', False) == 'True':
                 self.addons_paths.append(base_addons)

--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -1501,7 +1501,12 @@ class BaseRecipe(object):
 
         base_addons = join(self.openerp_dir, 'openerp', 'addons')
         if os.path.exists(base_addons):
-            self.addons_paths.insert(0, base_addons)
+            # Sometimes we don't want the base addons to be charged as the first ones 
+            # (if we have addons with the same names: like enterprise vs standard addons
+            if self.options.get('keep-addons-order', False) == 'True':
+                self.addons_paths.append(base_addons)
+            else:
+                self.addons_paths.insert(0, base_addons)
 
         self.insert_odoo_git_addons(base_addons)
 


### PR DESCRIPTION
…in the addons_path

If we want to use the enterprise addons, we must have the folder containing them as the first one in the addons_path, otherwise odoo will always install the community version.

So we have to put the enterprise addons folder as the first one in our buildout.cfg file and also add the option keep-addons-order. 
Example:

[openerp]
recipe = anybox.recipe.odoo:server

addons = 	git git@github.com:odoo/enterprise-9.git enterprise-9 master
		local ./project_addons/

keep-addons-order = True