### PR TITLE
[ADD] allow merging via sha1 hash

### DIFF
--- a/anybox/recipe/odoo/vcs/git.py
+++ b/anybox/recipe/odoo/vcs/git.py
@@ -223,7 +223,7 @@ class GitRepo(BaseRepo):
 
         return objtype == 'commit'
 
-    def fetch_remote_sha(self, sha):
+    def fetch_remote_sha(self, sha, checkout=True):
         """Fetch a precise SHA from remote if necessary.
 
         SHA pinning is suboptimal, can't be guaranteed to work (see the
@@ -249,7 +249,8 @@ class GitRepo(BaseRepo):
                 fetch_cmd.append(branch)
             self.log_call(fetch_cmd, callwith=update_check_call)
 
-        self.log_call(['git', 'checkout', sha])
+        if checkout:
+            self.log_call(['git', 'checkout', sha])
 
     def query_remote_ref(self, remote, ref):
         """Query remote repo about given ref.
@@ -388,6 +389,9 @@ class GitRepo(BaseRepo):
                                    "or non git local directory %s" %
                                    self.target_dir)
             os.chdir(self.target_dir)
+            rtype, sha = self.query_remote_ref(BUILDOUT_ORIGIN, revision)
+            if rtype is None and ishex(revision):
+                self.fetch_remote_sha(revision, checkout=False)
             cmd = ['git', 'pull', self.url, revision]
             if self.git_version >= (1, 7, 10):
                 # --edit and --no-edit appear with Git 1.7.10

--- a/anybox/recipe/odoo/vcs/tests/test_git.py
+++ b/anybox/recipe/odoo/vcs/tests/test_git.py
@@ -500,8 +500,9 @@ class GitMergeTestCase(GitBaseTestCase):
 
         self.make_branch(self.src_repo, 'branch1')
         self.checkout_branch(self.src_repo, 'branch1')
-        git_write_commit(self.src_repo, 'file_on_branch1',
-                         "file on branch 1", msg="on branch 1")
+        self.branch1_commit_sha1 = git_write_commit(
+            self.src_repo, 'file_on_branch1', "file on branch 1",
+            msg="on branch 1")
         self.checkout_branch(self.src_repo, 'master')
 
         self.make_branch(self.src_repo, 'branch2')
@@ -585,6 +586,18 @@ class GitMergeTestCase(GitBaseTestCase):
         self.assertFalse(os.path.exists(os.path.join(target_dir,
                                                      'file_on_branch1')),
                          'file_on_branch1 should not exist')
+
+    def test_04_merge_with_sha_pin(self):
+        target_dir = os.path.join(self.dst_dir, "to_repo")
+        repo = GitRepo(target_dir, self.src_repo)
+        repo('master')
+        print 'merging with sha'
+        git_set_user_info(repo.target_dir)
+        repo.merge(self.branch1_commit_sha1)
+        self.assertTrue(os.path.exists(os.path.join(target_dir,
+                                                    'file_on_branch1')),
+                        'file_on_branch1 should exist')
+        repo.revert('master')
 
 
 class GitTagTestCase(GitBaseTestCase):


### PR DESCRIPTION
for the same reasons as for addons, tagging is not always feasible, so we should allow pinning to commit hashes

PS: The message `fetch_remote_sha` is a bit annoying, would an option in the lines of `warn_git_sha1_pinning = {True,False}` with default to `True` be accepted if I PR it?