### PR TITLE
move env initialisation

### DIFF
--- a/anybox/recipe/odoo/runtime/session.py
+++ b/anybox/recipe/odoo/runtime/session.py
@@ -178,11 +178,9 @@ class Session(object):
         config['without_demo'] = saved_without_demo
         self.init_cursor()
         self.uid = SUPERUSER_ID
-        self.init_environments()
         self.context = self.registry('res.users').context_get(
             self.cr, self.uid)
-        if hasattr(openerp, 'api'):
-            self.env = openerp.api.Environment(self.cr, self.uid, self.context)
+        self.init_environments()
 
     def init_environments(self):
         """Enter the environments context manager, but don't leave it
@@ -208,6 +206,8 @@ class Session(object):
 
         self._environments_gen_context = gen_factory().gen
         self._environments_gen_context.next()
+        if hasattr(openerp, 'api'):
+            self.env = openerp.api.Environment(self.cr, self.uid, self.context)
 
     def clean_environments(self, reinit=True):
         """Cleans the thread-local environment.

--- a/tests_with_openerp/test_session.py
+++ b/tests_with_openerp/test_session.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+from anybox.recipe.odoo.runtime.session import Session
+from openerp.tests.common import get_db_name
+
+
+class SessionTestCase(TestCase):
+
+    def setUp(self):
+        super(SessionTestCase, self).setUp()
+        self.session = Session(None, None, parse_config=False)
+
+    def open_session(self):
+        self.session.open(db=get_db_name())
+
+    def test_env_after_install_module(self):
+        self.open_session()
+        self.assertAdminPresentWithV8API()
+        self.session.install_modules(['decimal_precision'])
+        self.assertAdminPresentWithV8API()
+
+    def assertAdminPresentWithV8API(self):
+        self.assertEqual(
+            u"Administrator",
+            self.session.env['res.users'].search([('login', '=', 'admin')]).name
+        )


### PR DESCRIPTION
When calling isntall_module() the env is lost so I moved
the env initialisation in clean env methods