### PR TITLE
[FIX] Freeze correct revision when using git merges

### DIFF
--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -1257,7 +1257,7 @@ class BaseRecipe(object):
 
         if revspec is not None and repo.is_local_fixed_revision(revspec):
             return revspec
-        parents = repo.parents(pip_compatible=pip_compatible)
+        parents = repo.parents(pip_compatible=pip_compatible, revspec=revspec)
         if len(parents) > 1:
             self.local_modifications.append(abspath)
 

--- a/anybox/recipe/odoo/testing.py
+++ b/anybox/recipe/odoo/testing.py
@@ -61,7 +61,7 @@ class FakeRepo(vcs.base.BaseRepo):
         self.revision = revision
         self.log.append(('revert', revision, self.target_dir))
 
-    def parents(self, pip_compatible=False):
+    def parents(self, pip_compatible=False, **kwargs):
         return [self.revision]
 
     def archive(self, target):

--- a/anybox/recipe/odoo/vcs/base.py
+++ b/anybox/recipe/odoo/vcs/base.py
@@ -178,7 +178,7 @@ class BaseRepo(object):
         """
         raise NotImplementedError
 
-    def parents(self, pip_compatible=False):
+    def parents(self, pip_compatible=False, revspec=False):
         """Return universal identifier for parent nodes, aka current revisions.
 
         There might be more than one with some VCSes (ex: pending merge in hg).
@@ -188,6 +188,10 @@ class BaseRepo(object):
                                reference/pip_install.html#vcs-support>`_
                                revision specifications are returned, depending
                                on the VCS type.
+        :param revspec: If set, the revision is used to find the base revision
+                        after merges. Merges lead to new commits which are
+                        unique to the local system and are not reproducible on
+                        other systems.
         """
         raise NotImplementedError
 

--- a/anybox/recipe/odoo/vcs/bzr.py
+++ b/anybox/recipe/odoo/vcs/bzr.py
@@ -149,7 +149,7 @@ class BzrBranch(BaseRepo):
             if line.startswith(prefix):
                 return 'revid:' + line[len(prefix):].strip()
 
-    def parents(self, as_revno=False, pip_compatible=False):
+    def parents(self, as_revno=False, pip_compatible=False, revspec=False):
         """Return current revision.
 
         :param as_revno: if ``True``, the revno will be returned. By default,

--- a/anybox/recipe/odoo/vcs/git.py
+++ b/anybox/recipe/odoo/vcs/git.py
@@ -153,14 +153,19 @@ class GitRepo(BaseRepo):
             os.chdir(self.target_dir)
             subprocess.check_call(['git', 'clean', '-fdqx'])
 
-    def parents(self, pip_compatible=False):
+    def parents(self, pip_compatible=False, revspec=False):
         """Return full hash of parent nodes.
 
         :param pip_compatible: ignored, all Git revspecs are pip compatible
         """
         with working_directory_keeper:
             os.chdir(self.target_dir)
-            p = subprocess.Popen(['git', 'rev-parse', '--verify', 'HEAD'],
+            cmd = ['git', 'rev-parse', '--verify', 'HEAD']
+            if revspec:
+                cmd = ['git', 'merge-base',
+                       '%s/%s' % (BUILDOUT_ORIGIN, revspec),
+                       revspec]
+            p = subprocess.Popen(cmd,
                                  stdout=subprocess.PIPE, env=SUBPROCESS_ENV)
             return p.communicate()[0].split()
 

--- a/anybox/recipe/odoo/vcs/hg.py
+++ b/anybox/recipe/odoo/vcs/hg.py
@@ -64,7 +64,7 @@ class HgRepo(BaseRepo):
         return bool(check_output(['hg', '--cwd', self.target_dir, 'status'],
                                  env=SUBPROCESS_ENV))
 
-    def parents(self, pip_compatible=False):
+    def parents(self, pip_compatible=False, revspec=False):
         """Return full hash of parent nodes.
 
         :param pip_compatible: ignored, all Hg revspecs are pip compatible


### PR DESCRIPTION
The current code doesn't handle freezes of git repositories correctly when
- the revision is not specified as a tag, and
- the merge option is used.

The merge option in git produces local commits hashes which are not reproducible on other systems. Currently the `freeze-to` command references this local merge commit.
This PR attempts to solve this issue by calling `git merge-base` to identify the correct base revision before the merges.

It's probably not an optimal solution because it requires API changes to all VCS classes, so I am happy to hear your suggestions.
