### PR TITLE
Pip compatibility branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ virtualenv:
 
 env:
   matrix:
+    - TEST_FOR_PIP='==1.4.1'  # the minimum version we require for now
     - TEST_FOR_PIP='<8.1'
     - TEST_FOR_PIP='==8.1.1'
     - TEST_FOR_PIP=">=8.1.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ virtualenv:
 
 env:
   matrix:
-    - PIP_VERSION='<8.1'
-    - PIP_VERSION='8.1.1'
-    - PIP_VERSION=">=8.1.2"
+    - TEST_FOR_PIP='<8.1'
+    - TEST_FOR_PIP='==8.1.1'
+    - TEST_FOR_PIP=">=8.1.2"
 
 before_install:
   # For tests running hg command
@@ -21,7 +21,7 @@ before_install:
 
 
 install:
-  - pip install --upgrade pip=${PIP_VERSION}
+  - pip install --upgrade pip${TEST_FOR_PIP}
   - pip install coveralls
   - pip install flake8
   - pip install -e .[test]

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ before_install:
   - echo 'username = anybox-test' >> ~/.hgrc
   # print setuptools version
   - easy_install --version
+  # if the wheel package is present, then pip will build an unusable wheel
+  # for zc.recipe.egg (see commit msg for analysis of that)
+  - pip uninstall -y wheel
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_install:
   # set up username
   - echo '[ui]' > ~/.hgrc
   - echo 'username = anybox-test' >> ~/.hgrc
+  # print setuptools version
+  - easy_install --version
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ python:
 virtualenv:
   system_site_packages: false
 
+env:
+  matrix:
+    - PIP_VERSION='<8.1'
+    - PIP_VERSION='8.1.1'
+    - PIP_VERSION=">=8.1.2"
+
 before_install:
   # For tests running hg command
   # set up username
@@ -15,6 +21,7 @@ before_install:
 
 
 install:
+  - pip install --upgrade pip=${PIP_VERSION}
   - pip install coveralls
   - pip install flake8
   - pip install -e .[test]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ upstream of anybox.recipe.odoo, and will change in the future.
 anybox.recipe.odoo 1.9.2 (unreleased)
 -------------------------------------
 - allow merging via sha1 hash
+- github #43: new option apply-requirements-file (and pip version
+  compatibilities handled in #76)
 - github #18: Support develop-dir option from gp.vcsdevelop
 - Odoo renaming in the doc
 - adapted nightly archive UR

--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -64,7 +64,22 @@ WITH_ODOO_REQUIREMENTS_FILE_OPTION = 'apply-requirements-file'
 
 def pip_version():
     import pip
-    return tuple(int(x) for x in pip.__version__.split('.'))
+    # we don't use pip or setuptools APIs for that to avoid going
+    # in a swath of instability.
+    # TODO we could try and use the version class from runtime.session
+    # (has the advantage over pkf_resources' of direct transparent
+    # comparison to tuples), but that'd introduced logical deps problems
+    # that I don't want to solve right now.
+
+    pip_version = pip.__version__
+    # Naturally, pip has strictly conformed to PEP440, and does not use
+    # version epochs, since at least v1.2. the oldest I could easily check
+    # (we claim to support >= 1.4.1).
+    # This equates all pre versions with the final one, and that's good
+    # enough for current purposes:
+    for suffix in ('a', 'b', 'rc', '.dev', '.post'):
+        pip_version = pip_version.split(suffix)[0]
+    return tuple(int(x) for x in pip_version.split('.'))
 
 
 class BaseRecipe(object):

--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -397,14 +397,19 @@ class BaseRecipe(object):
 
     def read_requirements_pip_before_v8(self, req_path, versions, develops):
         from pip.req import parse_requirements
-        # pip internals are protected against the fact of not passing
-        # a session with ``is None``. OTOH, the session is not used
-        # if the file is local (direct path, not an URL), so we cheat
-        # it.
-        # Although this hack still works with pip 8, it's considered to be
-        # the kind of thing that can depend on pip version
-        fake_session = object()
-        for inst_req in parse_requirements(req_path, session=fake_session):
+        if pip_version() < (1, 5):
+            parsed = parse_requirements(req_path)
+        else:
+            # pip internals are protected against the fact of not passing
+            # a session with ``is None``. OTOH, the session is not used
+            # if the file is local (direct path, not an URL), so we cheat
+            # it.
+            # Although this hack still works with pip 8, it's considered to be
+            # the kind of thing that can depend on pip version
+            fake_session = object()
+            parsed = parse_requirements(req_path, session=fake_session)
+
+        for inst_req in parsed:
             req = inst_req.req
             logger.debug("Considering requirement from Odoo's file %s",
                          req)

--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -389,7 +389,7 @@ class BaseRecipe(object):
         develops = self.list_develops()
 
         new_reqs = set()
-        if pip_version()[0] < 8:
+        if pip_version() < (8, 1, 2):
             self.read_requirements_pip_before_v8(req_path, versions, develops)
         else:
             self.read_requirements_pip_after_v8(req_path, versions, develops)
@@ -1232,9 +1232,12 @@ class BaseRecipe(object):
                 # name in requirement, whereas it used to just be the target
                 # directory
                 editable_options = getattr(ireq, 'editable_options', None)
-                if editable_options is not None:  # pip < 8
+                if editable_options is not None:  # pip < 8.1.0
                     return editable_options['egg']
-                return ireq.req.name  # pip 8
+                try:
+                    return ireq.req.name  # pip >= 8.1.2
+                except AttributeError:
+                    return ireq.req.project_name  # pip >=8.1.0, < 8.1.2
 
         ret = []
         for raw in option_splitlines(lines):


### PR DESCRIPTION
This branch fixes too issues that have arisen with recent pip versions (pip is used only for Oodoo requirements and gp.vcsdevelop support)

- pip 8.1.0 changed how the  `#egg` URL fragment is stored after parsing 
- pip 8.1.2 changed lots of representations for `InstallRequirement`: this is issue #76 
