### PR TITLE
Tests babel independency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ script:
   - python setup.py flake8
   - python setup.py nosetests
   # install sphinx only after running tests to avoid failing tests
+  # gracinet: after merging of the PR this commit concludes,
+  # installing sphinx should have no impact on the tests
   - pip install sphinx; python setup.py build_sphinx
 
 after_script:

--- a/anybox/recipe/odoo/testing.py
+++ b/anybox/recipe/odoo/testing.py
@@ -122,9 +122,9 @@ vcs.SUPPORTED['pr_fakevcs'] = PersistentRevFakeRepo
 class RecipeTestCase(unittest.TestCase):
     """A base setup for tests of recipe classes"""
 
-    fake_babel_dist_name = 'BabelFake'
-    fake_babel_name = 'babelfake'
-    fake_babel_version = None
+    fictive_dist_name = 'FictiveDist'
+    fictive_name = 'fictivedist'
+    fictive_version = None
 
     def setUp(self):
         b_dir = self.buildout_dir = mkdtemp('test_oerp_base_recipe')
@@ -177,9 +177,10 @@ class RecipeTestCase(unittest.TestCase):
         # leftover egg-info at root of the source dir (frequent cwd)
         # impairs use of this very same source dir for real-life testing
         # with a 'develop' option.
-        egg_info = self.fake_babel_dist_name + '.egg-info'
-        if os.path.isdir(egg_info):
-            shutil.rmtree(egg_info)
+        for egg_info in (self.fictive_dist_name + '.egg-info',
+                         'Babel.egg-info'):
+            if os.path.isdir(egg_info):
+                shutil.rmtree(egg_info)
 
     def build_babel_egg(self):
         """build an egg for fake babel in buildout's eggs directory.
@@ -196,20 +197,41 @@ class RecipeTestCase(unittest.TestCase):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
 
-    def fill_working_set(self):
-        self.build_babel_egg()
-        self.recipe.options['eggs'] = self.fake_babel_dist_name
+    def build_fictive_egg(self):
+        """build an egg of a fictive distribution for testing purposes.
+
+        Require the test case to already have a ``test_dir`` attribute
+        (typically set on class with the dirname of the test)
+        """
+        subprocess.check_call(
+            [sys.executable, 'setup.py',
+             'bdist_egg',
+             '-d', self.recipe.b_options['eggs-directory'],
+             '-b', os.path.join(self.buildout_dir, 'build')],
+            cwd=os.path.join(self.test_dir, 'fictive_dist'),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+
+    def fill_working_set(self, fictive=False, babel=False):
+        self.assertTrue(fictive or babel)
+        if babel:
+            self.build_babel_egg()
+            self.recipe.options['eggs'] = 'Babel'
+        if fictive:
+            self.build_fictive_egg()
+            self.recipe.options['eggs'] = self.fictive_dist_name
         self.recipe.install_requirements()  # to get 'ws' attribute
-        egg = self.recipe.ws.by_key.get(self.fake_babel_name)
-        if egg is None:
-            self.fail("Our crafted testing egg has not been installed")
-        # precise version depends on the setuptools version
-        # from setuptools 8.0, normalization to 0.123.dev0
-        # according to PEP440 occurs
-        self.assertTrue(egg.version.startswith('0.123'),
-                        msg="Our crafted testing egg "
-                        "is being superseded by %r" % egg)
-        self.fake_babel_version = egg.version
+        if fictive:
+            egg = self.recipe.ws.by_key.get(self.fictive_name)
+            if egg is None:
+                self.fail("Our crafted testing egg has not been installed")
+            # precise version depends on the setuptools version
+            # from setuptools 8.0, normalization to 0.123.dev0
+            # according to PEP440 occurs
+            self.assertTrue(egg.version.startswith('0.123'),
+                            msg="Our crafted testing egg "
+                            "is being superseded by %r" % egg)
+            self.fictive_version = egg.version
 
     def silence_buildout_develop(self):
         """Silence easy_install develop operations performed by zc.buildout.
@@ -222,3 +244,12 @@ class RecipeTestCase(unittest.TestCase):
             logger.warn("Could not grab zc.buildout.easy_install logger")
         else:
             zc_logger.setLevel(logging.ERROR)
+
+    def develop_fictive(self):
+        """Develop fictive distribution in buildout's directory.
+
+        Require the test case to already have a ``test_dir`` attribute
+        (typically set on class with the dirname of the test)
+        """
+        self.silence_buildout_develop()
+        return self.recipe.develop(os.path.join(self.test_dir, 'fictive_dist'))

--- a/anybox/recipe/odoo/testing.py
+++ b/anybox/recipe/odoo/testing.py
@@ -245,11 +245,18 @@ class RecipeTestCase(unittest.TestCase):
         else:
             zc_logger.setLevel(logging.ERROR)
 
-    def develop_fictive(self):
+    def develop_fictive(self, require_install=False):
         """Develop fictive distribution in buildout's directory.
 
         Require the test case to already have a ``test_dir`` attribute
         (typically set on class with the dirname of the test)
+
+        :param bool require_install: if ``True``, will be required from ``eggs``
+                                     option, and installed.
         """
         self.silence_buildout_develop()
-        return self.recipe.develop(os.path.join(self.test_dir, 'fictive_dist'))
+        res = self.recipe.develop(os.path.join(self.test_dir, 'fictive_dist'))
+        if require_install:
+            self.recipe.options['eggs'] = self.fictive_dist_name
+            self.recipe.install_requirements()
+        return res

--- a/anybox/recipe/odoo/testing.py
+++ b/anybox/recipe/odoo/testing.py
@@ -122,8 +122,8 @@ vcs.SUPPORTED['pr_fakevcs'] = PersistentRevFakeRepo
 class RecipeTestCase(unittest.TestCase):
     """A base setup for tests of recipe classes"""
 
-    fake_babel_dist_name = 'Babel'
-    fake_babel_name = 'babel'
+    fake_babel_dist_name = 'BabelFake'
+    fake_babel_name = 'babelfake'
     fake_babel_version = None
 
     def setUp(self):

--- a/anybox/recipe/odoo/testing.py
+++ b/anybox/recipe/odoo/testing.py
@@ -251,8 +251,8 @@ class RecipeTestCase(unittest.TestCase):
         Require the test case to already have a ``test_dir`` attribute
         (typically set on class with the dirname of the test)
 
-        :param bool require_install: if ``True``, will be required from ``eggs``
-                                     option, and installed.
+        :param bool require_install: if ``True``, will be required from
+                                     ``eggs`` option, and installed.
         """
         self.silence_buildout_develop()
         res = self.recipe.develop(os.path.join(self.test_dir, 'fictive_dist'))

--- a/anybox/recipe/odoo/tests/fake_babel/setup.py
+++ b/anybox/recipe/odoo/tests/fake_babel/setup.py
@@ -3,10 +3,11 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='BabelFake',
-    version='0.123',
+    name='Babel',
+    version='0.123',  # unlikely to exist ever
     description='Fake Babel',
-    long_description='Fake babel',
+    long_description="Satisfies hardcoded deps to babel, not to be "
+                     "used to test versions, freeze etc.",
     author='',
     author_email='',
     zip_safe=False,

--- a/anybox/recipe/odoo/tests/fake_babel/setup.py
+++ b/anybox/recipe/odoo/tests/fake_babel/setup.py
@@ -3,8 +3,8 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='Babel',
-    version='0.123',  # unlikely to exist ever
+    name='BabelFake',
+    version='0.123',
     description='Fake Babel',
     long_description='Fake babel',
     author='',

--- a/anybox/recipe/odoo/tests/fictive_dist/babel/__init__.py
+++ b/anybox/recipe/odoo/tests/fictive_dist/babel/__init__.py
@@ -1,0 +1,1 @@
+# this is a python package

--- a/anybox/recipe/odoo/tests/fictive_dist/setup.cfg
+++ b/anybox/recipe/odoo/tests/fictive_dist/setup.cfg
@@ -1,0 +1,3 @@
+[egg_info]
+tag_date = 0
+tag_build = -dev

--- a/anybox/recipe/odoo/tests/fictive_dist/setup.py
+++ b/anybox/recipe/odoo/tests/fictive_dist/setup.py
@@ -1,0 +1,14 @@
+# flake8: noqa
+
+from setuptools import setup, find_packages
+
+setup(
+    name='FictiveDist',
+    version='0.123',
+    description='Fictive Python dist',
+    long_description='Fictive Python distribution for testing',
+    author='',
+    author_email='',
+    zip_safe=False,
+    packages=find_packages(),
+)

--- a/anybox/recipe/odoo/tests/test_base.py
+++ b/anybox/recipe/odoo/tests/test_base.py
@@ -22,6 +22,10 @@ class TestingRecipe(BaseRecipe):
 
 class TestBaseRecipe(RecipeTestCase):
 
+    def setUp(self):
+        super(TestBaseRecipe, self).setUp()
+        self.test_dir = TEST_DIR
+
     def get_source_type(self):
         return self.recipe.sources[main_software][0]
 
@@ -141,11 +145,6 @@ class TestBaseRecipe(RecipeTestCase):
                 ):
             self.assertRaises(UserError,
                               recipe.parse_addons, dict(addons=illformed))
-
-    def develop_babel(self):
-        """Develop fake babel in buildout's directory"""
-        self.silence_buildout_develop()
-        return self.recipe.develop(os.path.join(TEST_DIR, 'fake_babel'))
 
     def test_clean(self):
         """Test clean for local server & addons and base class vcs addons.
@@ -392,18 +391,18 @@ class TestBaseRecipe(RecipeTestCase):
         self.make_recipe(
             version='git http://github.com/odoo/odoo.git odoo 7.0')
         self.assertEqual(self.recipe.list_develops(), [])
-        self.develop_babel()
+        self.develop_fictive()
         self.assertEqual(self.recipe.list_develops(),
-                         [self.fake_babel_dist_name])
+                         [self.fictive_dist_name])
 
     def test_apply_requirements_file_precedence2(self):
         """Unit test for Odoo requirements.txt: develops should win
         """
         self.make_recipe_appplying_requirements_file(
-            self.fake_babel_dist_name + "==6.2.3")
-        self.develop_babel()
+            self.fictive_dist_name + "==6.2.3")
+        self.develop_fictive()
         versions = self.apply_requirements_file()
-        self.assertFalse(self.fake_babel_dist_name in versions)
+        self.assertFalse(self.fictive_dist_name in versions)
 
     def test_apply_requirements_file_unsupported(self):
         """Unit test for Odoo requirements.txt: error paths #1

--- a/anybox/recipe/odoo/tests/test_base.py
+++ b/anybox/recipe/odoo/tests/test_base.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import subprocess
 from copy import deepcopy
 
 from zc.buildout import UserError

--- a/anybox/recipe/odoo/tests/test_base.py
+++ b/anybox/recipe/odoo/tests/test_base.py
@@ -145,14 +145,8 @@ class TestBaseRecipe(RecipeTestCase):
 
     def develop_babel(self):
         """Develop fake babel in buildout's directory"""
+        self.silence_buildout_develop()
         return self.recipe.develop(os.path.join(TEST_DIR, 'fake_babel'))
-
-        subprocess.check_call(
-            [sys.executable,
-             os.path.join(TEST_DIR, 'fake_babel', 'setup.py'),
-             'develop',
-             '-d', self.recipe.b_options['develop-eggs-directory'],
-             '-b', os.path.join(self.buildout_dir, 'build')])
 
     def test_clean(self):
         """Test clean for local server & addons and base class vcs addons.
@@ -400,15 +394,17 @@ class TestBaseRecipe(RecipeTestCase):
             version='git http://github.com/odoo/odoo.git odoo 7.0')
         self.assertEqual(self.recipe.list_develops(), [])
         self.develop_babel()
-        self.assertEqual(self.recipe.list_develops(), ['Babel'])
+        self.assertEqual(self.recipe.list_develops(),
+                         [self.fake_babel_dist_name])
 
     def test_apply_requirements_file_precedence2(self):
         """Unit test for Odoo requirements.txt: develops should win
         """
-        self.make_recipe_appplying_requirements_file("Babel==6.2.3")
+        self.make_recipe_appplying_requirements_file(
+            self.fake_babel_dist_name + "==6.2.3")
         self.develop_babel()
         versions = self.apply_requirements_file()
-        self.assertFalse('Babel' in versions)
+        self.assertFalse(self.fake_babel_dist_name in versions)
 
     def test_apply_requirements_file_unsupported(self):
         """Unit test for Odoo requirements.txt: error paths #1

--- a/anybox/recipe/odoo/tests/test_extract.py
+++ b/anybox/recipe/odoo/tests/test_extract.py
@@ -184,7 +184,5 @@ class TestExtraction(RecipeTestCase):
 
         self.assertEqual(ext_conf.get('openerp', 'version').strip(),
                          'local parts/odooo')
-        # precise version depends on the setuptools version
-        # from about setuptools 8.2 or 8.3, normalization to 0.123.dev0
-        # according to PEP440 occurs
-        self.assertTrue(ext_conf.get('versions', 'babel').startswith('0.123'))
+        self.assertEqual(ext_conf.get('versions', self.fake_babel_name),
+                         self.fake_babel_version)

--- a/anybox/recipe/odoo/tests/test_extract.py
+++ b/anybox/recipe/odoo/tests/test_extract.py
@@ -171,7 +171,7 @@ class TestExtraction(RecipeTestCase):
         os.mkdir(os.path.join(self.recipe.openerp_dir))
         self.recipe.retrieve_main_software()
         self.recipe.retrieve_addons()
-        self.fill_working_set()
+        self.fill_working_set(fictive=True)
 
         self.recipe.extract_downloads_to(self.extract_target_dir)
         ext_conf = ConfigParser()
@@ -184,5 +184,5 @@ class TestExtraction(RecipeTestCase):
 
         self.assertEqual(ext_conf.get('openerp', 'version').strip(),
                          'local parts/odooo')
-        self.assertEqual(ext_conf.get('versions', self.fake_babel_name),
-                         self.fake_babel_version)
+        self.assertEqual(ext_conf.get('versions', self.fictive_name),
+                         self.fictive_version)

--- a/anybox/recipe/odoo/tests/test_freeze.py
+++ b/anybox/recipe/odoo/tests/test_freeze.py
@@ -18,14 +18,14 @@ class TestFreeze(RecipeTestCase):
         conf = ConfigParser()
         conf.add_section('freeze')
         self.make_recipe(version='8.0')
-        self.fill_working_set()
+        self.fill_working_set(fictive=True)
         self.recipe._freeze_egg_versions(conf, 'freeze')
         try:
-            version = conf.get('freeze', self.fake_babel_dist_name)
+            version = conf.get('freeze', self.fictive_dist_name)
         except NoOptionError:
             self.fail("Expected version of %s "
-                      "egg not dumped !" % self.fake_babel_dist_name)
-        self.assertEqual(version, self.fake_babel_version)
+                      "egg not dumped !" % self.fictive_dist_name)
+        self.assertEqual(version, self.fictive_version)
 
     def test_freeze_egg_versions_merge(self):
         """Test that freezing of egg versions keeps eggs already dumped.
@@ -36,9 +36,7 @@ class TestFreeze(RecipeTestCase):
         conf.add_section('freeze')
         conf.set('freeze', 'some.distribution', '1.0alpha')
         self.make_recipe(version='8.0')
-        self.build_babel_egg()
-        self.recipe.options['eggs'] = self.fake_babel_dist_name
-        self.recipe.install_requirements()  # to get 'ws' attribute
+        self.fill_working_set(fictive=True)
         self.recipe._freeze_egg_versions(conf, 'freeze')
         try:
             version = conf.get('freeze', 'some.distribution')
@@ -52,13 +50,12 @@ class TestFreeze(RecipeTestCase):
         conf = ConfigParser()
         conf.add_section('freeze')
         self.make_recipe(version='8.0')
-        self.silence_buildout_develop()
-        self.recipe.develop(os.path.join(self.test_dir, 'fake_babel'))
-        self.recipe.options['eggs'] = self.fake_babel_dist_name
+        self.develop_fictive()
+        self.recipe.options['eggs'] = self.fictive_dist_name
         self.recipe.install_requirements()  # to get 'ws' attribute
         self.recipe._freeze_egg_versions(conf, 'freeze')
         self.assertRaises(NoOptionError, conf.get, 'freeze',
-                          self.fake_babel_dist_name)
+                          self.fictive_dist_name)
 
     def test_freeze_vcs_source(self):
         self.make_recipe(version='8.0')
@@ -183,7 +180,7 @@ class TestFreeze(RecipeTestCase):
         os.mkdir(os.path.join(self.recipe.openerp_dir))
         self.recipe.retrieve_main_software()
         self.recipe.retrieve_addons()
-        self.fill_working_set()
+        self.fill_working_set(babel=True)
 
         tmpdir = tempfile.mkdtemp('test_recipe_freeze')
         frozen_path = os.path.join(tmpdir, 'frozen.cfg')

--- a/anybox/recipe/odoo/tests/test_freeze.py
+++ b/anybox/recipe/odoo/tests/test_freeze.py
@@ -21,10 +21,11 @@ class TestFreeze(RecipeTestCase):
         self.fill_working_set()
         self.recipe._freeze_egg_versions(conf, 'freeze')
         try:
-            version = conf.get('freeze', 'Babel')
+            version = conf.get('freeze', self.fake_babel_dist_name)
         except NoOptionError:
-            self.fail("Expected version of Babel egg not dumped !")
-        self.assertTrue(version.startswith('0.123'))
+            self.fail("Expected version of %s "
+                      "egg not dumped !" % self.fake_babel_dist_name)
+        self.assertEqual(version, self.fake_babel_version)
 
     def test_freeze_egg_versions_merge(self):
         """Test that freezing of egg versions keeps eggs already dumped.
@@ -36,7 +37,7 @@ class TestFreeze(RecipeTestCase):
         conf.set('freeze', 'some.distribution', '1.0alpha')
         self.make_recipe(version='8.0')
         self.build_babel_egg()
-        self.recipe.options['eggs'] = 'Babel'
+        self.recipe.options['eggs'] = self.fake_babel_dist_name
         self.recipe.install_requirements()  # to get 'ws' attribute
         self.recipe._freeze_egg_versions(conf, 'freeze')
         try:
@@ -51,11 +52,13 @@ class TestFreeze(RecipeTestCase):
         conf = ConfigParser()
         conf.add_section('freeze')
         self.make_recipe(version='8.0')
+        self.silence_buildout_develop()
         self.recipe.develop(os.path.join(self.test_dir, 'fake_babel'))
-        self.recipe.options['eggs'] = 'Babel'
+        self.recipe.options['eggs'] = self.fake_babel_dist_name
         self.recipe.install_requirements()  # to get 'ws' attribute
         self.recipe._freeze_egg_versions(conf, 'freeze')
-        self.assertRaises(NoOptionError, conf.get, 'freeze', 'Babel')
+        self.assertRaises(NoOptionError, conf.get, 'freeze',
+                          self.fake_babel_dist_name)
 
     def test_freeze_vcs_source(self):
         self.make_recipe(version='8.0')

--- a/anybox/recipe/odoo/tests/test_freeze.py
+++ b/anybox/recipe/odoo/tests/test_freeze.py
@@ -50,9 +50,7 @@ class TestFreeze(RecipeTestCase):
         conf = ConfigParser()
         conf.add_section('freeze')
         self.make_recipe(version='8.0')
-        self.develop_fictive()
-        self.recipe.options['eggs'] = self.fictive_dist_name
-        self.recipe.install_requirements()  # to get 'ws' attribute
+        self.develop_fictive(require_install=True)
         self.recipe._freeze_egg_versions(conf, 'freeze')
         self.assertRaises(NoOptionError, conf.get, 'freeze',
                           self.fictive_dist_name)


### PR DESCRIPTION
Since last spring, Anybox's buildbot has had test failures on the recipe that were overlooked, because as far as unit tests go, it's been superseded by Travis, and I guess that's why the Travis sequence installs Sphinx only after the tests have passed.

Anyway, the tests did fail if Babel was installed in the virtualenv, now they don't and it's saner.