### PR TITLE
[FIX] don't crash on <= v7

### DIFF
--- a/anybox/recipe/odoo/runtime/session.py
+++ b/anybox/recipe/odoo/runtime/session.py
@@ -181,7 +181,8 @@ class Session(object):
         self.init_environments()
         self.context = self.registry('res.users').context_get(
             self.cr, self.uid)
-        self.env.context = self.context
+        if hasattr(openerp, 'api'):
+            self.env.context = self.context
 
     def init_environments(self):
         """Enter the environments context manager, but don't leave it


### PR DESCRIPTION
this fixes a regression introduced by https://github.com/anybox/anybox.recipe.odoo/commit/bbd313b54d216eabc846102312c738c8917eea18, causing upgrade to fail on v7 installations