### PR TITLE
[IMP] add sorting when generating the frozen file. 

### DIFF
--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -1167,7 +1167,9 @@ class BaseRecipe(object):
         conf_ensure_section(out_conf, self.name)
         addons_option = []
         self.local_modifications = []
-        for local_path, source in self.sources.items():
+        sources_list = self.sources.items()
+        sources_list.sort(key=lambda a: a[1][0]) # sort by src
+        for local_path, source in sources_list:
             source_type = source[0]
             if source_type == 'local':
                 continue
@@ -1323,7 +1325,9 @@ class BaseRecipe(object):
                         if name not in exclude and
                         egg.precedence != pkg_resources.DEVELOP_DIST
                         )
-        for name, version in versions.items():
+        versions_list = versions.items()
+        versions_list.sort()
+        for name, version in versions_list:
             conf.set(section, name, version)
 
         # forbidding picked versions if this zc.buildout supports it right away


### PR DESCRIPTION
The aim is to order by name for the python package and by src for the odoo part.
Indeed having odoo package ordering by src allow to check quickly where the code come from, and so to push the team to merge the src into the oca branch and use only oca branch ;)
