### PR TITLE
Option for skipping checkout of existing repositories

### DIFF
--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -185,12 +185,10 @@ class BaseRecipe(object):
         # GR: would prefer lower() but doing as in 'zc.recipe.egg'
         # (later) the standard way for all booleans is to use
         # options.query_bool() or get_bool(), but it doesn't lower() at all
-        self.offline = self.b_options['offline'] == 'true'
-        self.clean = options.get('clean') == 'true'
-        clear_locks = options.get('vcs-clear-locks', '').lower()
-        self.vcs_clear_locks = clear_locks == 'true'
-        clear_retry = options.get('vcs-clear-retry', '').lower()
-        self.clear_retry = clear_retry == 'true'
+        self.offline = self.bool_opt_get('offline', is_global=True)
+        self.clean = self.bool_opt_get('clean')
+        self.vcs_clear_locks = self.bool_opt_get('vcs-clear-locks')
+        self.clear_retry = self.bool_opt_get('vcs-clear-retry')
 
         if self.bool_opt_get(WITH_ODOO_REQUIREMENTS_FILE_OPTION):
             logger.debug("%s option: adding 'pip' to the recipe requirements",

--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -846,6 +846,7 @@ class BaseRecipe(object):
             loc_type, loc_spec, addons_options = source_spec
             local_dir = self.make_absolute(local_dir)
             options = dict(offline=self.offline,
+                           skip_checkout=self.bool_opt_get('skip-checkout'),
                            clear_locks=self.vcs_clear_locks,
                            clean=self.clean)
             if loc_type == 'git':

--- a/anybox/recipe/odoo/vcs/base.py
+++ b/anybox/recipe/odoo/vcs/base.py
@@ -1,4 +1,5 @@
 import os
+import os.path
 import shutil
 import subprocess
 import logging
@@ -105,6 +106,12 @@ class BaseRepo(object):
     def __call__(self, revision):
         """Create if needed from remote source, and put it at wanted revision.
         """
+        if (self.options.get('skip_checkout') and
+                os.path.exists(self.target_dir)):
+            logger.info("Directory exists and skip-checkout is active. Skipping: %s",
+                        self.target_dir)
+            return self
+
         if self.options.get('clean'):
             self.clean()
 

--- a/anybox/recipe/odoo/vcs/tests/test_base.py
+++ b/anybox/recipe/odoo/vcs/tests/test_base.py
@@ -4,6 +4,7 @@ These tests depend on system executables, such as 'hg', 'bzr', etc.
 """
 
 import os
+import os.path
 import subprocess
 
 from zc.buildout import UserError
@@ -35,6 +36,26 @@ class CommonTestCase(testing.VcsTestCase):
         repo = BaseRepo('/some/path', 'http://some/url')
         self.assertEqual(str(repo), "BaseRepo at '/some/path' "
                          "(remote='http://some/url')")
+
+    def test_skip_checkout(self):
+        existing_dir = self.dst_dir
+        non_existing_dir = os.path.join(existing_dir + 'foo')
+
+        # Repos should try checkout when not called with skip_checkout
+        self.assertRaises(
+            NotImplementedError, BaseRepo(existing_dir, 'http://some/url')
+        )
+        # Specially when the target doesn't exist
+        self.assertRaises(
+            NotImplementedError, BaseRepo(non_existing_dir, 'http://some/url')
+        )
+        # But also when called with skip_checkout and the target doesn't exist
+        self.assertRaises(
+            NotImplementedError,
+            BaseRepo(non_existing_dir, 'http://some/url', skip_checkout=True)
+        )
+        # But not when it exists
+        BaseRepo(existing_dir, 'http://some/url', skip_checkout=True)
 
     def test_unknown(self):
         self.assertRaises(UserError,


### PR DESCRIPTION
Checking out lots of addon repositories (or even the huge `odoo` repo itself) can take a long time, and sometimes we just want to re-run buildout for some other purpose, like rebuilding `odoo.cfg`.

This PR adds an option for skipping the checkout of a repo if the target already exists.

It's mostly to be used from the buildout command line, like:

     bin/buildout odoo:skip-checkout=true