### PR TITLE
Merge in offline mode + in online mode, look for local SHAs first

### DIFF
--- a/anybox/recipe/odoo/vcs/git.py
+++ b/anybox/recipe/odoo/vcs/git.py
@@ -318,6 +318,9 @@ class GitRepo(BaseRepo):
                         "If you get a related error below, that won't be "
                         "a recipe bug.",
                         self.target_dir, revision)
+ 
+        if self.offline and self.options.get('merge'):
+            return self.offline_merge(revision)
 
         if self.options.get('merge'):
             return self.merge(revision)
@@ -338,6 +341,10 @@ class GitRepo(BaseRepo):
                            BUILDOUT_ORIGIN, url],
                           log_level=logging.DEBUG)
 
+            # if pinned, try to find on local first
+            if ishex(revision) and self.has_commit(revision):
+                self.log_call(['git', 'checkout', revision])
+                return
             rtype, sha = self.query_remote_ref(BUILDOUT_ORIGIN, revision)
             if rtype is None and ishex(revision):
                 return self.fetch_remote_sha(revision)
@@ -405,6 +412,26 @@ class GitRepo(BaseRepo):
                     self.log_call(['git', 'reset', '--hard', 'FETCH_HEAD'],
                                   callwith=update_check_call)
 
+    def _no_edit(self, cmd):
+        if self.git_version >= (1, 7, 10):
+            # --edit and --no-edit appear with Git 1.7.10
+            # see Documentation/RelNotes/1.7.10.txt of Git
+            # (https://git.kernel.org/cgit/git/git.git/tree)
+            cmd.insert(2, '--no-edit')
+        return cmd
+
+    def offline_merge(self, revision):
+        """Merge revision into current branch"""
+        if ishex(revision):
+            if not self.has_commit(revision):
+                raise UserError("Commit %s not found in git repository "
+                                "%s (offline mode)" % (revision, self))
+        elif not self._is_a_branch(revision):
+            raise UserError("Branch %s not found in git repository "
+                            "%s (offline mode)" % (revision, self))
+        cmd = self._no_edit(['git', 'merge', revision])
+        self.log_call(cmd)
+
     def merge(self, revision):
         """Merge revision into current branch"""
         with working_directory_keeper:
@@ -413,17 +440,18 @@ class GitRepo(BaseRepo):
                                    "or non git local directory %s" %
                                    self.target_dir)
             os.chdir(self.target_dir)
+            if ishex(revision) and self.has_commit(revision):
+                # if pinned, try to find on local first
+                cmd = ['git', 'merge', revision]
+                self.log_call(self._no_edit(cmd))
+                return
+
             rtype, sha = self.query_remote_ref(BUILDOUT_ORIGIN, revision)
             if rtype is None and ishex(revision):
                 self.fetch_remote_sha(revision, checkout=False)
             cmd = ['git', 'pull', self.url, revision]
-            if self.git_version >= (1, 7, 10):
-                # --edit and --no-edit appear with Git 1.7.10
-                # see Documentation/RelNotes/1.7.10.txt of Git
-                # (https://git.kernel.org/cgit/git/git.git/tree)
-                cmd.insert(2, '--no-edit')
 
-            self.log_call(cmd)
+            self.log_call(self._no_edit(cmd))
 
     def archive(self, target_path):
         # TODO: does this work with merge-ins?


### PR DESCRIPTION
I found that:

1. In offline mode, merges are still fetched from the internet which is not allowed
2. In online mode, if a pinned SHA is already there locally, it is still pulled from online, thus making operation unnecessary slow

This PR addresses both issues.
