### PR TITLE
[FIX] Rollback pip version check to make it compatible with Ubuntu 16.04

### DIFF
--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -408,7 +408,7 @@ class BaseRecipe(object):
         develops = self.list_develops()
 
         new_reqs = set()
-        if pip_version() < (8, 1, 2):
+        if pip_version() < (8, 1, 1):
             self.read_requirements_pip_before_v8(req_path, versions, develops)
         else:
             self.read_requirements_pip_after_v8(req_path, versions, develops)


### PR DESCRIPTION
The specific revision used for pip 8 check (8.1.2) seems arbitrary. This PR rollback the check to allow the default Ubuntu 16.04 python-pip package (8.1.1) work. This fix an incompatibility issue between Ubuntu 16.04 and the recipe with newer zc.buildout version (>9.0). 