### PR TITLE
Preparing 1.9.3 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,11 @@ This changelog displays timelines for the two recipes
 
 anybox.recipe.odoo 1.9.3 (UNRELEASED)
 -------------------------------------
--
+- github #90: PyChart special cases no longer needed
+- github #93: Empty log file from upgrade_script
+- github #88: Support from Odoo 8.0 to odoo 10.0
+- github #110: Odoo 11.0 RegistryManager is removed
+- github #108: Python3 compatibility (Odoo 11.0)
 
 anybox.recipe.odoo 1.9.2 (2016-09-20)
 -------------------------------------


### PR DESCRIPTION
Once this PR merged, I'll push a new commit directly on the repo with the release date + a new tag 1.9.3.
@petrus-v regarding the publication on PyPI, how do we proceed?

Later I'll try to fix the Travis tests (+ drop support for old pip versions which do not work anymore anyway).