### PR TITLE
[FIX] Do not prefetch all fields when retrieving the user context

### DIFF
--- a/anybox/recipe/odoo/runtime/session.py
+++ b/anybox/recipe/odoo/runtime/session.py
@@ -195,7 +195,8 @@ class Session(object):
         self.init_cursor()
         self.uid = SUPERUSER_ID
         self.init_environments()
-        self.context = self.env['res.users'].context_get()
+        self.context = self.env['res.users'].with_context(
+            prefetch_fields=False).context_get()
         self.env = odoo.api.Environment(self.cr, self.uid, self.context)
 
     def init_environments(self):


### PR DESCRIPTION
This crashes Odoo >= 10.0 when we add fields on 'res.users' or 'res.partner' data models while the module is not yet updated (the field does not exist in the database).

```python
2018-03-07 14:47:45,267 2001 INFO dev_20180220 odoo.modules.loading: Modules loaded.
2018-03-07 14:47:45,274 2001 INFO dev_20180220 odoo.sql_db: bad query:  SELECT "res_partner"."customer" as "customer","res_partner"."notify_email" as "notify_email","res_partner"."debit_limit" as "debit_limit","res_partner"."street2" as "street2","res_partner"."display_name" as "display_name","res_partner"."signup_expiration" as "signup_expiration","res_partner"."active" as "active","res_partner"."write_date" as "write_date","res_partner"."last_time_entries_checked" as "last_time_entries_checked","res_partner"."opt_out" as "opt_out","res_partner"."lang" as "lang","res_partner"."city" as "city","res_partner"."country_id" as "country_id","res_partner"."credit_limit" as "credit_limit","res_partner"."tz" as "tz","res_partner"."message_bounce" as "message_bounce","res_partner"."invoice_warn_msg" as "invoice_warn_msg","res_partner"."sale_warn_msg" as "sale_warn_msg","res_partner"."sale_warn" as "sale_warn","res_partner"."lastname" as "lastname","res_partner"."title" as "title","res_partner"."test_field2" as "test_field2","res_partner"."partner_share" as "partner_share","res_partner"."message_last_post" as "message_last_post","res_partner"."picking_warn" as "picking_warn","res_partner"."test_field" as "test_field","res_partner"."supplier" as "supplier","res_partner"."barcode" as "barcode","res_partner"."user_id" as "user_id","res_partner"."signup_token" as "signup_token","res_partner"."phone" as "phone","res_partner"."zip" as "zip","res_partner"."function" as "function","res_partner"."write_uid" as "write_uid","res_partner"."company_id" as "company_id","res_partner"."fax" as "fax","res_partner"."color" as "color","res_partner"."picking_warn_msg" as "picking_warn_msg","res_partner"."invoice_warn" as "invoice_warn","res_partner"."mobile" as "mobile","res_partner"."commercial_company_name" as "commercial_company_name","res_partner"."signup_type" as "signup_type","res_partner"."ref" as "ref","res_partner"."email" as "email","res_partner"."is_company" as "is_company","res_partner"."employee" as "employee","res_partner"."state_id" as "state_id","res_partner"."id" as "id","res_partner"."purchase_warn" as "purchase_warn","res_partner"."comment" as "comment","res_partner"."name" as "name","res_partner"."company_name" as "company_name","res_partner"."firstname" as "firstname","res_partner"."create_uid" as "create_uid","res_partner"."type" as "type","res_partner"."date" as "date","res_partner"."create_date" as "create_date","res_partner"."purchase_warn_msg" as "purchase_warn_msg","res_partner"."website" as "website","res_partner"."vat" as "vat","res_partner"."street" as "street","res_partner"."commercial_partner_id" as "commercial_partner_id","res_partner"."parent_id" as "parent_id","res_partner"."team_id" as "team_id" FROM "res_partner"
                        WHERE "res_partner".id IN (3)  ORDER BY "res_partner"."display_name"  
                    
Traceback (most recent call last):
  File "./bin/upgrade_odoo", line 77, in <module>
    sys.exit(anybox.recipe.odoo.runtime.upgrade.upgrade('/home/odoo/odoo/upgrade.py', 'run_dev', '/home/odoo/odoo/etc/odoo.cfg', '/home/odoo/odoo'))
  File "/home/odoo/odoo/eggs/anybox.recipe.odoo-1.9.3.dev0-py2.7.egg/anybox/recipe/odoo/runtime/upgrade.py", line 118, in upgrade
    session.open(db=db_name, with_demo=bool(arguments.init_load_demo_data))
  File "/home/odoo/odoo/eggs/anybox.recipe.odoo-1.9.3.dev0-py2.7.egg/anybox/recipe/odoo/runtime/session.py", line 193, in open
    self.context = self.env['res.users'].context_get()
  File "<decorator-gen-30>", line 2, in context_get
  File "/home/odoo/odoo/parts/OCB-8995576f4a810457cdcdfc6304c1ed37e7866a89/odoo/tools/cache.py", line 87, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/home/odoo/odoo/parts/OCB-8995576f4a810457cdcdfc6304c1ed37e7866a89/odoo/addons/base/res/res_users.py", line 424, in context_get
    res = getattr(user, k) or False
  File "/home/odoo/odoo/parts/OCB-8995576f4a810457cdcdfc6304c1ed37e7866a89/odoo/fields.py", line 910, in __get__
    self.determine_value(record)
  File "/home/odoo/odoo/parts/OCB-8995576f4a810457cdcdfc6304c1ed37e7866a89/odoo/fields.py", line 1022, in determine_value
    self.compute_value(recs)
  File "/home/odoo/odoo/parts/OCB-8995576f4a810457cdcdfc6304c1ed37e7866a89/odoo/fields.py", line 976, in compute_value
    self._compute_value(records)
  File "/home/odoo/odoo/parts/OCB-8995576f4a810457cdcdfc6304c1ed37e7866a89/odoo/fields.py", line 969, in _compute_value
    self.compute(records)
  File "/home/odoo/odoo/parts/OCB-8995576f4a810457cdcdfc6304c1ed37e7866a89/odoo/fields.py", line 620, in _compute_related
    record[self.name] = value[self.related_field.name]
  File "/home/odoo/odoo/parts/OCB-8995576f4a810457cdcdfc6304c1ed37e7866a89/odoo/models.py", line 5211, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "/home/odoo/odoo/parts/OCB-8995576f4a810457cdcdfc6304c1ed37e7866a89/odoo/fields.py", line 910, in __get__
    self.determine_value(record)
  File "/home/odoo/odoo/parts/OCB-8995576f4a810457cdcdfc6304c1ed37e7866a89/odoo/fields.py", line 1012, in determine_value
    record._prefetch_field(self)
  File "/home/odoo/odoo/parts/OCB-8995576f4a810457cdcdfc6304c1ed37e7866a89/odoo/models.py", line 3065, in _prefetch_field
    result = records.read([f.name for f in fs], load='_classic_write')
  File "/home/odoo/odoo/parts/OCB-8995576f4a810457cdcdfc6304c1ed37e7866a89/odoo/models.py", line 3009, in read
    self._read_from_database(stored, inherited)
  File "/home/odoo/odoo/parts/OCB-8995576f4a810457cdcdfc6304c1ed37e7866a89/odoo/models.py", line 3133, in _read_from_database
    cr.execute(query_str, params)
  File "/home/odoo/odoo/parts/OCB-8995576f4a810457cdcdfc6304c1ed37e7866a89/odoo/sql_db.py", line 154, in wrapper
    return f(self, *args, **kwargs)
  File "/home/odoo/odoo/parts/OCB-8995576f4a810457cdcdfc6304c1ed37e7866a89/odoo/sql_db.py", line 231, in execute
    res = self._obj.execute(query, params)
psycopg2.ProgrammingError: ERREUR:  la colonne res_partner.test_field2 n'existe pas
LINE 1: ...e" as "lastname","res_partner"."title" as "title","res_partn...
```