### PR TITLE
[FIX] codec error for python 3.6 and pip 10.x.x compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(
     description="A buildout recipe to install and configure Odoo",
     license="AGPLv3+",
     long_description='\n'.join((
-        open('README.rst').read(),
-        open('CHANGES.rst').read())),
+        open('README.rst', encoding="utf-8").read(),
+        open('CHANGES.rst', encoding="utf-8").read())),
     url="https://github.com/anybox/anybox.recipe.odoo",
     packages=find_packages(),
     namespace_packages=['anybox', 'anybox.recipe'],


### PR DESCRIPTION
a.r.odoo/setup.py", line 30, in <module>
[localhost] out:     open('README.rst').read(),
[localhost] out:   File "../archetipo/devel/odoo11/prj/sandbox/bin/../lib/python3.6/encodings/ascii.py", line 26, in decode
[localhost] out:     return codecs.ascii_decode(input, self.errors)[0]
[localhost] out: UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1741: ordinal not in range(128)
[localhost] out: While:
[localhost] out:   Installing.
[localhost] out:   Processing develop directory '../archetipo/devel/odoo11/prj/a.r.odoo'.