### PR TITLE
[ADD] ``preserve_options`` option.

### DIFF
--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -264,6 +264,8 @@ class BaseRecipe(object):
         if self.preserve_options:
             self.preserve_options_config_path = '{config_path}.preserve'.format(config_path=self.config_path)
 
+        self.default_admin_passwd = options.get('default_admin_passwd', '')
+
         for d in self.downloads_dir, self.etc:
             if not os.path.exists(d):
                 logger.info('Created %s/ directory' % basename(d))

--- a/anybox/recipe/odoo/server.py
+++ b/anybox/recipe/odoo/server.py
@@ -101,8 +101,7 @@ class ServerRecipe(BaseRecipe):
     def _create_default_config(self):
         """Have Odoo generate its default config file.
         """
-        if 'admin_passwd' not in self.preserve_options:
-            self.options.setdefault('options.admin_passwd', '')
+        self.options.setdefault('options.admin_passwd', self.default_admin_passwd)
 
         sys.path.append(self.odoo_dir)
         sys.path.extend([egg.location for egg in self.ws])

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -355,6 +355,18 @@ setting ``git-warn-sha-pins = False``.
              if the remote repository gets lots of rebasing. If
              possible, pinning on tags is always to be preferred.
 
+.. _preserve_addons:
+
+The ``preserve_options`` option
+-------------------------------
+
+The ``preserve_options`` (option) specifies which Odoo config-options
+shall be preserved during builds. Especially for changed options like
+the (hashed) ``admin_passwd``, manually set by the Odoo web-interface,
+this prevents reversal to defaults. If at least 1 option is specified,
+the ``etc/odoo.cfg`` file shall be copied to ``etc/odoo.cfg.preserve``
+on every build.
+
 .. _merges:
 
 merges


### PR DESCRIPTION
The ``preserve_options`` (option) specifies which Odoo config-options shall be preserved during builds. Especially for changed options like the (hashed) ``admin_passwd``, manually set by the Odoo web-interface, this prevents reversal to defaults. If at least 1 option is specified, the ``etc/odoo.cfg`` file shall be copied to ``etc/odoo.cfg.preserve`` on every build.