### PR TITLE
[ADD] default_admin_passwd and preserve_admin_passwd (options)

### DIFF
--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -265,7 +265,7 @@ class BaseRecipe(object):
         self.preserve_admin_passwd = options.get('preserve_admin_passwd', 'False') == 'True'
         self.prev_config_path  = False
 
-        if self.preserve_admin_passwd and os.path.exists(self.config_path):
+        if self.preserve_admin_passwd:
             self.prev_config_path = '{config_path}.prev'.format(config_path=self.config_path)
 
         for d in self.downloads_dir, self.etc:

--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -1168,6 +1168,9 @@ class BaseRecipe(object):
             conf_ensure_section(config, section)
 
             # If preserve admin_passwd extract from prev_config and write in build config.
+            logger.info('Option: preserve_admin_passwd = %s', self.preserve_admin_passwd)
+            logger.info('prev_config_path: %s', self.prev_config_path)
+            logger.info('prev_config_path (path) exists: %s', os.path.exists(self.prev_config_path))
             if option == 'admin_passwd' and self.preserve_admin_passwd and \
                self.prev_config_path and os.path.exists(self.prev_config_path):
                 # TODO match not a commented admin_passwd. So without a # on line (negate regex).
@@ -1177,8 +1180,8 @@ class BaseRecipe(object):
                 with open(self.prev_config_path, 'r') as f:
                     fdata = f.read()
                     matches = re.findall(pattern_admin_passwd, fdata)
-                    logger.critical(matches)
                     if len(matches) == 1:
+                        logger.info('Found admin_passwd to preserve')
                         preserve_admin_passwd = matches[0][1].strip()
                     else:
                         msg = 'Found {count} matches of admin_passwd'.format(count=len(matches))

--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -1168,9 +1168,6 @@ class BaseRecipe(object):
             conf_ensure_section(config, section)
 
             # If preserve admin_passwd extract from prev_config and write in build config.
-            logger.info('Option: preserve_admin_passwd = %s', self.preserve_admin_passwd)
-            logger.info('prev_config_path: %s', self.prev_config_path)
-            logger.info('prev_config_path (path) exists: %s', os.path.exists(self.prev_config_path))
             if option == 'admin_passwd' and self.preserve_admin_passwd and \
                self.prev_config_path and os.path.exists(self.prev_config_path):
                 # TODO match not a commented admin_passwd. So without a # on line (negate regex).

--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -259,6 +259,15 @@ class BaseRecipe(object):
         self.etc = self.make_absolute(options.get('etc-directory', 'etc'))
         self.bin_dir = self.buildout['buildout']['bin-directory']
         self.config_path = join(self.etc, self.name + '.cfg')
+
+        self.default_admin_passwd = options.get('default_admin_passwd', '')
+
+        self.preserve_admin_passwd = options.get('preserve_admin_passwd', 'False') == 'True'
+        self.prev_config_path  = False
+
+        if self.preserve_admin_passwd and os.path.exists(self.config_path):
+            self.prev_config_path = '{config_path}.prev'.format(config_path=self.config_path)
+
         for d in self.downloads_dir, self.etc:
             if not os.path.exists(d):
                 logger.info('Created %s/ directory' % basename(d))
@@ -1142,6 +1151,8 @@ class BaseRecipe(object):
 
         # create the config file
         if os.path.exists(self.config_path):
+            if self.prev_config_path:
+                shutil.copyfile(self.config_path, self.prev_config_path)
             os.remove(self.config_path)
         logger.info('Creating config file: %s',
                     os.path.relpath(self.config_path, self.buildout_dir))
@@ -1155,7 +1166,30 @@ class BaseRecipe(object):
                 continue
             section, option = recipe_option.split('.', 1)
             conf_ensure_section(config, section)
-            config.set(section, option, self.options[recipe_option])
+
+            # If preserve admin_passwd extract from prev_config and write in build config.
+            if option == 'admin_passwd' and self.preserve_admin_passwd and \
+               self.prev_config_path and os.path.exists(self.prev_config_path):
+                # TODO match not a commented admin_passwd. So without a # on line (negate regex).
+                pattern_admin_passwd = re.compile("(admin_passwd\s*=\s*)(\S+)")
+                preserve_admin_passwd = False
+
+                with open(self.prev_config_path, 'r') as f:
+                    fdata = f.read()
+                    matches = re.findall(pattern_admin_passwd, fdata)
+                    logger.critical(matches)
+                    if len(matches) == 1:
+                        preserve_admin_passwd = matches[0][1].strip()
+                    else:
+                        msg = 'Found {count} matches of admin_passwd'.format(count=len(matches))
+                        raise UserError(msg)
+
+                if preserve_admin_passwd:
+                    config.set(section, option, preserve_admin_passwd)
+                else:
+                    config.set(section, option, self.options[recipe_option])
+            else:
+                config.set(section, option, self.options[recipe_option])
         with open(self.config_path, 'w') as configfile:
             config.write(configfile)
 

--- a/anybox/recipe/odoo/server.py
+++ b/anybox/recipe/odoo/server.py
@@ -99,7 +99,7 @@ class ServerRecipe(BaseRecipe):
     def _create_default_config(self):
         """Have Odoo generate its default config file.
         """
-        self.options.setdefault('options.admin_passwd', '')
+        self.options.setdefault('options.admin_passwd', self.default_admin_passwd)
         sys.path.append(self.odoo_dir)
         sys.path.extend([egg.location for egg in self.ws])
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -355,6 +355,27 @@ setting ``git-warn-sha-pins = False``.
              if the remote repository gets lots of rebasing. If
              possible, pinning on tags is always to be preferred.
 
+.. _default_admin_passwd:
+
+The ``default_admin_passed`` option
+------------------------------------
+
+The ``default_admin_passwd`` (option) specifies a custom
+``admin_passwd`` to be stored during the build.
+
+.. _preserve_admin_passwd:
+
+The ``preserve_admin_passed`` option
+------------------------------------
+
+The ``preserve_admin_passwd = True`` (option) specifies the
+``admin_passwd`` (stored in the Odoo config file) shall be preserved
+during builds. This is especially critical if the ``admin_passwd`` had
+been summitted from the Odoo web-interface and stored encrypted (as
+hash).  So this option prevents reversal to the default
+``admin_passwd``. On every build, the ``etc/odoo.cfg`` file shall be
+copied to ``etc/odoo.cfg.prev``.
+
 .. _merges:
 
 merges


### PR DESCRIPTION
The ``default_admin_passwd`` (option) specifies a custom ``admin_passwd`` to be stored during the build.

The ``preserve_admin_passwd = True`` (option) specifies the ``admin_passwd`` (stored in the Odoo config file) shall be preserved during builds. This is especially critical if the ``admin_passwd`` had
been summitted from the Odoo web-interface and stored encrypted (as hash).  So this option prevents reversal to the default ``admin_passwd``. On every build, the ``etc/odoo.cfg`` file shall be
copied to ``etc/odoo.cfg.prev``.