### PR TITLE
[FIX] Pinning of git merges

### DIFF
--- a/anybox/recipe/odoo/vcs/git.py
+++ b/anybox/recipe/odoo/vcs/git.py
@@ -242,7 +242,8 @@ class GitRepo(BaseRepo):
                         self.target_dir)
         branch = self.options.get('branch')
         if not self.has_commit(sha):
-            fetch_cmd = ['git', 'fetch', BUILDOUT_ORIGIN]
+            remote = BUILDOUT_ORIGIN if checkout else self.url
+            fetch_cmd = ['git', 'fetch', remote]
             if branch is None:
                 logger.info("%s: SHA pinning without remote "
                             "branch indication. "
@@ -413,10 +414,12 @@ class GitRepo(BaseRepo):
                                    "or non git local directory %s" %
                                    self.target_dir)
             os.chdir(self.target_dir)
-            rtype, sha = self.query_remote_ref(BUILDOUT_ORIGIN, revision)
+            rtype, sha = self.query_remote_ref(self.url, revision)
             if rtype is None and ishex(revision):
                 self.fetch_remote_sha(revision, checkout=False)
-            cmd = ['git', 'pull', self.url, revision]
+                cmd = ['git', 'merge', revision]
+            else:
+                cmd = ['git', 'pull', self.url, revision]
             if self.git_version >= (1, 7, 10):
                 # --edit and --no-edit appear with Git 1.7.10
                 # see Documentation/RelNotes/1.7.10.txt of Git


### PR DESCRIPTION
This change allows the buildout recipe to support merges like
   `git https://github.com/MyTeam/odoo parts/odoo 01234567890abcdef branch=my_branch`

By checking the git reference against the correct repo, the remote revision
will be imported correctly in the local repo. It can then be merged (not
pulled) into the local branch.