### PR TITLE
[FIX] Browse user without prefetch when opening database

### DIFF
--- a/anybox/recipe/odoo/runtime/session.py
+++ b/anybox/recipe/odoo/runtime/session.py
@@ -195,7 +195,8 @@ class Session(object):
         self.init_cursor()
         self.uid = SUPERUSER_ID
         self.init_environments()
-        self.context = self.env['res.users'].context_get()
+        self.context = self.env['res.users'].with_context(
+            prefetch_fields=False).context_get()
         self.env = odoo.api.Environment(self.cr, self.uid, self.context)
 
     def init_environments(self):


### PR DESCRIPTION
When running bin/upgrade_odoo, the database is loaded once to fetch the current
database patch level. In the process, the user is browsed and by extension,
the partner_id that it inherits. If the modules that are installed in the
database have added a new field on the user or partner model that has not yet
been instantiated in the database tables, the loading of the database will
fail with an UndefinedColumn exception at that point.

By disabling prefetching of fields, only the columns will be read of the fields
that are actually being requested (in this case lang and tz). This prevents
the ORM from trying to read all the columns that it thinks are in the table,
including the newly added fields.