### PR TITLE
[FIX] Python 2.x: prevent dependencies in unicode format

### DIFF
--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -479,7 +479,7 @@ class BaseRecipe(object):
             if project_name not in self.requirements:
                 # TODO maybe convert self.requirements to a set (in
                 # next unstable branch)
-                self.requirements.append(project_name)
+                self.requirements.append(str(project_name))
 
             if inst_req.markers:
                 logger.warn("Requirement %s has a marker %s but the evaluation"
@@ -559,7 +559,7 @@ class BaseRecipe(object):
             if project_name not in self.requirements:
                 # TODO maybe convert self.requirements to a set (in
                 # next unstable branch)
-                self.requirements.append(project_name)
+                self.requirements.append(str(project_name))
 
             if project_name in versions:
                 logger.debug("Requirement from Odoo's file %s superseded "


### PR DESCRIPTION
Fixes

```
  File "/home/odoo/anybox.recipe.odoo/anybox/recipe/odoo/base.py", line 1175, in install
    self.install_requirements()
  File "/home/odoo/anybox.recipe.odoo/anybox/recipe/odoo/base.py", line 608, in install_requirements
    self.apply_odoo_requirements_file()
  File "/home/odoo/anybox.recipe.odoo/anybox/recipe/odoo/base.py", line 453, in apply_odoo_requirements_file
    self.merge_requirements()
  File "/home/odoo/anybox.recipe.odoo/anybox/recipe/odoo/server.py", line 107, in merge_requirements
    BaseRecipe.merge_requirements(self, reqs=reqs)
  File "/home/odoo/anybox.recipe.odoo/anybox/recipe/odoo/base.py", line 389, in merge_requirements
    self.options['eggs'] += '\n' + serial
  File "/home/odoo/venv/py2/lib/python2.7/site-packages/zc/buildout/buildout.py", line 1566, in __setitem__
    raise TypeError('Option values must be strings', value)
TypeError: ('Option values must be strings', u'gevent\nunidecode\nopenupgradelib\npypdf2\nsimplejson\nxlrd <snip>
```

when building a Python 2.x setup with `apply-requirements-file = true`;